### PR TITLE
Deps, interpolate, SVG

### DIFF
--- a/client/assets/classic/images/game/ammos/0.svg
+++ b/client/assets/classic/images/game/ammos/0.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
+<svg width="52.45" height="36.86" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/classic/images/game/ammos/1.svg
+++ b/client/assets/classic/images/game/ammos/1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
+<svg width="52.45" height="36.86" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/classic/images/game/ammos/2.svg
+++ b/client/assets/classic/images/game/ammos/2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
+<svg width="52.45" height="36.86" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/classic/images/game/ammos/3.svg
+++ b/client/assets/classic/images/game/ammos/3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
+<svg width="52.45" height="36.86" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/classic/images/game/proc-items/backpack/1.svg
+++ b/client/assets/classic/images/game/proc-items/backpack/1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46.3 46.63">
+<svg width="46.3" height="46.63" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46.3 46.63">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/classic/images/game/proc-items/backpack/2.svg
+++ b/client/assets/classic/images/game/proc-items/backpack/2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64.36 53.63">
+<svg width="64.36" height="53.63" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64.36 53.63">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/classic/images/game/proc-items/backpack/3.svg
+++ b/client/assets/classic/images/game/proc-items/backpack/3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72.58 57.91">
+<svg width="72.58" height="57.91" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72.58 57.91">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/classic/images/game/proc-items/helmet/1.svg
+++ b/client/assets/classic/images/game/proc-items/helmet/1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
+<svg width="40.09" height="40.09" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/classic/images/game/proc-items/helmet/2.svg
+++ b/client/assets/classic/images/game/proc-items/helmet/2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
+<svg width="40.09" height="40.09" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/classic/images/game/proc-items/helmet/3.svg
+++ b/client/assets/classic/images/game/proc-items/helmet/3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
+<svg width="40.09" height="40.09" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/HUD/guns/ghi_cqbr.svg
+++ b/client/assets/normal/images/game/HUD/guns/ghi_cqbr.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50.78 56.53">
+<svg width="50.78" height="56.53" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50.78 56.53">
   <defs>
     <style>
       .cls-1, .cls-2 {

--- a/client/assets/normal/images/game/HUD/guns/ghi_m18.svg
+++ b/client/assets/normal/images/game/HUD/guns/ghi_m18.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 41.5 61.3">
+<svg width="41.5" height="61.3" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 41.5 61.3">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/HUD/guns/ghi_mp9.svg
+++ b/client/assets/normal/images/game/HUD/guns/ghi_mp9.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 57.79 61.64">
+<svg width="57.79" height="61.64" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 57.79 61.64">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/HUD/guns/ghi_stf12.svg
+++ b/client/assets/normal/images/game/HUD/guns/ghi_stf12.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50.81 60.36">
+<svg width="50.81" height="60.36" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 50.81 60.36">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/HUD/guns/ghi_svd-m.svg
+++ b/client/assets/normal/images/game/HUD/guns/ghi_svd-m.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 51.74 55.35">
+<svg width="51.74" height="55.35" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 51.74 55.35">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/ammos/0.svg
+++ b/client/assets/normal/images/game/ammos/0.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
+<svg width="52.45" height="36.86" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/ammos/1.svg
+++ b/client/assets/normal/images/game/ammos/1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
+<svg width="52.45" height="36.86" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/ammos/2.svg
+++ b/client/assets/normal/images/game/ammos/2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
+<svg width="52.45" height="36.86" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/ammos/3.svg
+++ b/client/assets/normal/images/game/ammos/3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
+<svg width="52.45" height="36.86" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 52.45 36.86">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/fists/default.svg
+++ b/client/assets/normal/images/game/fists/default.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26.55 26.55">
+<svg width="26.55" height="26.55" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26.55 26.55">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/guns/cqbr.svg
+++ b/client/assets/normal/images/game/guns/cqbr.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15.95 96.73">
+<svg width="15.95" height="96.73" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 15.95 96.73">
   <defs>
     <style>
       .cls-1, .cls-2, .cls-3, .cls-4, .cls-5, .cls-6 {

--- a/client/assets/normal/images/game/guns/gwi_kacamg_body.svg
+++ b/client/assets/normal/images/game/guns/gwi_kacamg_body.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16.36 102.36">
+<svg width="16.36" height="102.36" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16.36 102.36">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/guns/gwi_kacamg_mag.svg
+++ b/client/assets/normal/images/game/guns/gwi_kacamg_mag.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 27.26 13.69">
+<svg width="27.26" height="13.69" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 27.26 13.69">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/guns/gwi_meusoc.svg
+++ b/client/assets/normal/images/game/guns/gwi_meusoc.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.66 32.42">
+<svg width="11.66" height="32.42" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.66 32.42">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/guns/gwi_msbs.svg
+++ b/client/assets/normal/images/game/guns/gwi_msbs.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.59 109.7">
+<svg width="18.59" height="109.7" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.59 109.7">
   <defs>
     <style>
       .cls-1, .cls-2, .cls-3, .cls-4 {

--- a/client/assets/normal/images/game/guns/m18.svg
+++ b/client/assets/normal/images/game/guns/m18.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.66 32.43">
+<svg width="11.66" height="32.43" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.66 32.43">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/guns/mp9.svg
+++ b/client/assets/normal/images/game/guns/mp9.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14.48 61.13">
+<svg width="14.48" height="61.13" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 14.48 61.13">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/guns/stf_12.svg
+++ b/client/assets/normal/images/game/guns/stf_12.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.82 88.05">
+<svg width="12.82" height="88.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 12.82 88.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/guns/svd-m.svg
+++ b/client/assets/normal/images/game/guns/svd-m.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20.46 128.01">
+<svg width="20.46" height="128.01" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20.46 128.01">
   <defs>
     <style>
       .cls-1, .cls-2, .cls-3, .cls-4, .cls-5 {

--- a/client/assets/normal/images/game/loot_bag1.svg
+++ b/client/assets/normal/images/game/loot_bag1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loot_bag2.svg
+++ b/client/assets/normal/images/game/loot_bag2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loot_bag3.svg
+++ b/client/assets/normal/images/game/loot_bag3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/backpacks/1.svg
+++ b/client/assets/normal/images/game/loots/backpacks/1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/backpacks/2.svg
+++ b/client/assets/normal/images/game/loots/backpacks/2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/backpacks/3.svg
+++ b/client/assets/normal/images/game/loots/backpacks/3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/healings/coffee.svg
+++ b/client/assets/normal/images/game/loots/healings/coffee.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.06 62.06">
+<svg width="62.06" height="62.06" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.06 62.06">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/healings/energy_drink.svg
+++ b/client/assets/normal/images/game/loots/healings/energy_drink.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.06 62.06">
+<svg width="62.06" height="62.06" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.06 62.06">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/healings/medkit.svg
+++ b/client/assets/normal/images/game/loots/healings/medkit.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.06 62.06">
+<svg width="62.06" height="62.06" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.06 62.06">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/healings/pie.svg
+++ b/client/assets/normal/images/game/loots/healings/pie.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.06 62.06">
+<svg width="62.06" height="62.06" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.06 62.06">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/healings/tourniquet.svg
+++ b/client/assets/normal/images/game/loots/healings/tourniquet.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.06 62.06">
+<svg width="62.06" height="62.06" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.06 62.06">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/proc-items/helmet-level-1.svg
+++ b/client/assets/normal/images/game/loots/proc-items/helmet-level-1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/proc-items/helmet-level-2.svg
+++ b/client/assets/normal/images/game/loots/proc-items/helmet-level-2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/proc-items/helmet-level-3.svg
+++ b/client/assets/normal/images/game/loots/proc-items/helmet-level-3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/proc-items/vest-level-1.svg
+++ b/client/assets/normal/images/game/loots/proc-items/vest-level-1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/proc-items/vest-level-2.svg
+++ b/client/assets/normal/images/game/loots/proc-items/vest-level-2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/proc-items/vest-level-3.svg
+++ b/client/assets/normal/images/game/loots/proc-items/vest-level-3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/scopes/zoom-15x.svg
+++ b/client/assets/normal/images/game/loots/scopes/zoom-15x.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 72.68 72.68">
+<svg width="72.68" height="72.68" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 72.68 72.68">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/scopes/zoom-2x.svg
+++ b/client/assets/normal/images/game/loots/scopes/zoom-2x.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 72.68 72.68">
+<svg width="72.68" height="72.68" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 72.68 72.68">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/scopes/zoom-4x.svg
+++ b/client/assets/normal/images/game/loots/scopes/zoom-4x.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 72.68 72.68">
+<svg width="72.68" height="72.68" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 72.68 72.68">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/scopes/zoom-8x.svg
+++ b/client/assets/normal/images/game/loots/scopes/zoom-8x.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 72.68 72.68">
+<svg width="72.68" height="72.68" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 72.68 72.68">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/cqbr.svg
+++ b/client/assets/normal/images/game/loots/weapons/cqbr.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1, .cls-2 {

--- a/client/assets/normal/images/game/loots/weapons/m18.svg
+++ b/client/assets/normal/images/game/loots/weapons/m18.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/mp9.svg
+++ b/client/assets/normal/images/game/loots/weapons/mp9.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/new/gli_cqbr.svg
+++ b/client/assets/normal/images/game/loots/weapons/new/gli_cqbr.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1, .cls-2 {

--- a/client/assets/normal/images/game/loots/weapons/new/gli_kacamg.svg
+++ b/client/assets/normal/images/game/loots/weapons/new/gli_kacamg.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/new/gli_m18.svg
+++ b/client/assets/normal/images/game/loots/weapons/new/gli_m18.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/new/gli_meusoc.svg
+++ b/client/assets/normal/images/game/loots/weapons/new/gli_meusoc.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/new/gli_mp9.svg
+++ b/client/assets/normal/images/game/loots/weapons/new/gli_mp9.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/new/gli_msbs.svg
+++ b/client/assets/normal/images/game/loots/weapons/new/gli_msbs.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/new/gli_stf12.svg
+++ b/client/assets/normal/images/game/loots/weapons/new/gli_stf12.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/new/gli_svdm.svg
+++ b/client/assets/normal/images/game/loots/weapons/new/gli_svdm.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/new/gli_vector.svg
+++ b/client/assets/normal/images/game/loots/weapons/new/gli_vector.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/stf_12.svg
+++ b/client/assets/normal/images/game/loots/weapons/stf_12.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/loots/weapons/svd-m.svg
+++ b/client/assets/normal/images/game/loots/weapons/svd-m.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
+<svg width="81.31" height="81.31" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 81.31 81.31">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/barrel.svg
+++ b/client/assets/normal/images/game/objects/barrel.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88.72 88.72">
+<svg width="88.72" height="88.72" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88.72 88.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/barrelDirty.svg
+++ b/client/assets/normal/images/game/objects/barrelDirty.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88.72 88.72">
+<svg width="88.72" height="88.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 88.72 88.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/box.svg
+++ b/client/assets/normal/images/game/objects/box.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 97.31 64.89">
+<svg width="97.31" height="64.89" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 97.31 64.89">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/bush.svg
+++ b/client/assets/normal/images/game/objects/bush.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 114 114">
+<svg width="114" height="114" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 114 114">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/concrete_pillar.svg
+++ b/client/assets/normal/images/game/objects/concrete_pillar.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.62 78.61">
+<svg width="78.62" height="78.61" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.62 78.61">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/crate.svg
+++ b/client/assets/normal/images/game/objects/crate.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 115.16 115.16">
+<svg width="115.16" height="115.16" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 115.16 115.16">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/crate_plus.svg
+++ b/client/assets/normal/images/game/objects/crate_plus.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 115.16 115.16">
+<svg width="115.16" height="115.16" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 115.16 115.16">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/desk.svg
+++ b/client/assets/normal/images/game/objects/desk.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 146.59 81.04">
+<svg width="146.59" height="81.04" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 146.59 81.04">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/log_1.svg
+++ b/client/assets/normal/images/game/objects/log_1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30.81 29.98">
+<svg width="30.81" height="29.98" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30.81 29.98">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/log_2.svg
+++ b/client/assets/normal/images/game/objects/log_2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
+<svg width="34.08" height="26.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/log_3.svg
+++ b/client/assets/normal/images/game/objects/log_3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
+<svg width="34.08" height="26.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/log_4.svg
+++ b/client/assets/normal/images/game/objects/log_4.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30.81 29.98">
+<svg width="30.81" height="29.98" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30.81 29.98">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/log_5.svg
+++ b/client/assets/normal/images/game/objects/log_5.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
+<svg width="34.08" height="26.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/log_stump.svg
+++ b/client/assets/normal/images/game/objects/log_stump.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 89.64 92.99">
+<svg width="89.64" height="92.99" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 89.64 92.99">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/pillar.svg
+++ b/client/assets/normal/images/game/objects/pillar.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.62 78.61">
+<svg width="78.62" height="78.61" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.62 78.61">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/residues/box.svg
+++ b/client/assets/normal/images/game/objects/residues/box.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.17 60.64">
+<svg width="78.17" height="60.64" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 78.17 60.64">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/residues/crate.svg
+++ b/client/assets/normal/images/game/objects/residues/crate.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84.93 84.92">
+<svg width="84.93" height="84.92" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84.93 84.92">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/residues/crate_plus.svg
+++ b/client/assets/normal/images/game/objects/residues/crate_plus.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84.93 84.92">
+<svg width="84.93" height="84.92" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 84.93 84.92">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/residues/log_1.svg
+++ b/client/assets/normal/images/game/objects/residues/log_1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
+<svg width="18.73" height="18.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/residues/log_2.svg
+++ b/client/assets/normal/images/game/objects/residues/log_2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
+<svg width="18.73" height="18.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/residues/log_3.svg
+++ b/client/assets/normal/images/game/objects/residues/log_3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
+<svg width="18.73" height="18.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/residues/log_4.svg
+++ b/client/assets/normal/images/game/objects/residues/log_4.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
+<svg width="18.73" height="18.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/residues/log_5.svg
+++ b/client/assets/normal/images/game/objects/residues/log_5.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
+<svg width="18.73" height="18.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/residues/stump.svg
+++ b/client/assets/normal/images/game/objects/residues/stump.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 39.84 37.56">
+<svg width="39.84" height="37.56" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 39.84 37.56">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/residues/woodpile.svg
+++ b/client/assets/normal/images/game/objects/residues/woodpile.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96.94 65.91">
+<svg width="96.94" height="65.91" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96.94 65.91">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/stone.svg
+++ b/client/assets/normal/images/game/objects/stone.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 118.7 108.92">
+<svg width="118.7" height="108.92" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 118.7 108.92">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/tree.svg
+++ b/client/assets/normal/images/game/objects/tree.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 351.89 355.5">
+<svg width="351.89" height="355.5" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" version="1.1" viewBox="0 0 351.89 355.5">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/objects/woodpile.svg
+++ b/client/assets/normal/images/game/objects/woodpile.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 94.84 89.45">
+<svg width="94.84" height="89.45" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 94.84 89.45">
   <defs>
     <style>
       .cls-1, .cls-2, .cls-3 {

--- a/client/assets/normal/images/game/particles/case_12ga.svg
+++ b/client/assets/normal/images/game/particles/case_12ga.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 13.37 5.62">
+<svg width="13.37" height="5.62" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 13.37 5.62">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/particles/case_large.svg
+++ b/client/assets/normal/images/game/particles/case_large.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17.1 6.02">
+<svg width="17.1" height="6.02" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 17.1 6.02">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/particles/case_med.svg
+++ b/client/assets/normal/images/game/particles/case_med.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.11 4.42">
+<svg width="11.11" height="4.42" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 11.11 4.42">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/particles/case_small.svg
+++ b/client/assets/normal/images/game/particles/case_small.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8.26 4.38">
+<svg width="8.26" height="4.38" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8.26 4.38">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/proc-items/backpack/1.svg
+++ b/client/assets/normal/images/game/proc-items/backpack/1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46.3 46.63">
+<svg width="46.3" height="46.63" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 46.3 46.63">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/proc-items/backpack/2.svg
+++ b/client/assets/normal/images/game/proc-items/backpack/2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64.36 53.63">
+<svg width="64.36" height="53.63" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64.36 53.63">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/proc-items/backpack/3.svg
+++ b/client/assets/normal/images/game/proc-items/backpack/3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72.58 57.91">
+<svg width="72.58" height="57.91" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 72.58 57.91">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/proc-items/helmet/1.svg
+++ b/client/assets/normal/images/game/proc-items/helmet/1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
+<svg width="40.09" height="40.09" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/proc-items/helmet/2.svg
+++ b/client/assets/normal/images/game/proc-items/helmet/2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
+<svg width="40.09" height="40.09" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/proc-items/helmet/3.svg
+++ b/client/assets/normal/images/game/proc-items/helmet/3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
+<svg width="40.09" height="40.09" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 40.09 40.09">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/skins/default.svg
+++ b/client/assets/normal/images/game/skins/default.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66.89 66.89">
+<svg width="66.89" height="66.89" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 66.89 66.89">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/floor.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/floor.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 457.37 231.94">
+<svg width="457.37" height="231.94" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 457.37 231.94">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/obs_log1.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/obs_log1.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30.81 29.98">
+<svg width="30.81" height="29.98" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30.81 29.98">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/obs_log2.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/obs_log2.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
+<svg width="34.08" height="26.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/obs_log3.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/obs_log3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
+<svg width="34.08" height="26.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/obs_log4.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/obs_log4.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30.81 29.98">
+<svg width="30.81" height="29.98" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 30.81 29.98">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/obs_log5.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/obs_log5.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
+<svg width="34.08" height="26.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 34.08 26.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/obs_stump.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/obs_stump.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 89.64 92.99">
+<svg width="89.64" height="92.99" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 89.64 92.99">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/obs_woodpile.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/obs_woodpile.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 94.84 89.45">
+<svg width="94.84" height="89.45" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 94.84 89.45">
   <defs>
     <style>
       .cls-1, .cls-2, .cls-3 {

--- a/client/assets/normal/images/game/textures/fixed/WS/residue_log.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/residue_log.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
+<svg width="18.73" height="18.72" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 18.73 18.72">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/residue_stump.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/residue_stump.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 39.84 37.56">
+<svg width="39.84" height="37.56" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 39.84 37.56">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/residue_woodpile.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/residue_woodpile.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96.94 65.91">
+<svg width="96.94" height="65.91" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 96.94 65.91">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/roof.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/roof.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 358.75 185.62">
+<svg width="358.75" height="185.62" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 358.75 185.62">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/roof_shadow_woodshack.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/roof_shadow_woodshack.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350.75 177.63">
+<svg width="350.75" height="177.63" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 350.75 177.63">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/WS/wall_woodshack.svg
+++ b/client/assets/normal/images/game/textures/fixed/WS/wall_woodshack.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 39.49 20">
+<svg width="39.49" height="20" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 39.49 20">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/floor_conex_blue.svg
+++ b/client/assets/normal/images/game/textures/fixed/floor_conex_blue.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 371.03 163.87">
+<svg width="371.03" height="163.87" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 371.03 163.87">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/floor_conex_red.svg
+++ b/client/assets/normal/images/game/textures/fixed/floor_conex_red.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 371.03 163.87">
+<svg width="371.03" height="163.87" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 371.03 163.87">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/floor_warehouse.svg
+++ b/client/assets/normal/images/game/textures/fixed/floor_warehouse.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 795.85 1388.43">
+<svg width="795.85" height="1388.43" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 795.85 1388.43">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/game/textures/fixed/roof_warehouse.svg
+++ b/client/assets/normal/images/game/textures/fixed/roof_warehouse.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_3" data-name="Layer 3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 802.85 1396.43">
+<svg width="802.85" height="1396.43" id="Layer_3" data-name="Layer 3" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 802.85 1396.43">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/normal/images/menu/ilndr_logo_text.svg
+++ b/client/assets/normal/images/menu/ilndr_logo_text.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 452.77 169.95">
+<svg width="452.77" height="169.95" id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 452.77 169.95">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/suroi_collab/loot_bag3.svg
+++ b/client/assets/suroi_collab/loot_bag3.svg
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
+<svg width="62.05" height="62.05" id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 62.05 62.05">
   <defs>
     <style>
       .cls-1 {

--- a/client/assets/svg-fixer.ts
+++ b/client/assets/svg-fixer.ts
@@ -1,0 +1,32 @@
+import * as fs from "fs";
+import * as path from "path";
+
+function fixDir(relPath: string) {
+	fs.readdir(relPath, (err, files) => {
+		if (err) return console.error(err);
+		for (const file of files) {
+			const filePath = path.join(relPath, file);
+			fs.stat(filePath, (err, stats) => {
+				if (err) return console.error(err);
+				if (stats.isDirectory()) fixDir(filePath);
+				else if (file.endsWith(".svg")) {
+					fs.readFile(filePath, { encoding: "utf8" }, (err, content) => {
+						const lines = content.split("\n");
+						const ii = lines.findIndex((line) => line.startsWith("<svg"));
+						if (!/width="\d+(\.\d+)?"/g.test(lines[ii]) && !/height="\d+(\.\d+)?"/g.test(lines[ii])) {
+							const match = lines[ii].match(/viewBox="(?<x>\d+(\.\d+)?) +(?<y>\d+(\.\d+)?) +(?<w>\d+(\.\d+)?) +(?<h>\d+(\.\d+)?)"/);
+							if (match?.groups) {
+								const width = Number(match.groups.w) - Number(match.groups.x);
+								const height = Number(match.groups.h) - Number(match.groups.y);
+								lines[ii] = `<svg width="${width}" height="${height}"${lines[ii].split("<svg").pop()}`;
+								fs.writeFile(filePath, lines.join("\n"), console.error);
+							}
+						}
+					});
+				}
+			});
+		}
+	});
+}
+
+fixDir(path.join(__dirname));

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
+        "@damienvesper/bit-buffer": "^1.0.1",
         "axios": "^1.6.0",
         "cookies-utils": "^1.0.0",
         "dotenv": "^16.3.1",
@@ -34,6 +35,15 @@
         "browserify-shim": "^3.8.16",
         "typescript": "^4.7.2",
         "uglify-js": "^3.17.4"
+      }
+    },
+    "node_modules/@damienvesper/bit-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@damienvesper/bit-buffer/-/bit-buffer-1.0.1.tgz",
+      "integrity": "sha512-9sRpqNevbCxTmI05mBA3WdaAB4P467XP7aiA/zwOZtWdAS90wIuokeZz9hrUgQlUUKAC4f5+/zqrblV6XdlnLA==",
+      "engines": {
+        "node": ">=18.8.0",
+        "pnpm": ">=8.6.0"
       }
     },
     "node_modules/@types/howler": {
@@ -2503,6 +2513,11 @@
     }
   },
   "dependencies": {
+    "@damienvesper/bit-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@damienvesper/bit-buffer/-/bit-buffer-1.0.1.tgz",
+      "integrity": "sha512-9sRpqNevbCxTmI05mBA3WdaAB4P467XP7aiA/zwOZtWdAS90wIuokeZz9hrUgQlUUKAC4f5+/zqrblV6XdlnLA=="
+    },
     "@types/howler": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@types/howler/-/howler-2.2.7.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -32,6 +32,7 @@
     "uglify-js": "^3.17.4"
   },
   "dependencies": {
+    "@damienvesper/bit-buffer": "^1.0.1",
     "axios": "^1.6.0",
     "cookies-utils": "^1.0.0",
     "dotenv": "^16.3.1",

--- a/client/src/deserialisers.ts
+++ b/client/src/deserialisers.ts
@@ -136,7 +136,8 @@ export function deserialiseMinObstacles(stream: IslandrBitStream): MinObstacle[]
             despawn: stream.readBoolean(),
             animations: <string[]>_getAnimations(stream),
             roofless: new Set<string>(),
-            special: "normal"
+            special: "normal",
+            _needToSendAnimations: false, // TODO: make this actually read
         }
         if (obstacle.type == ObstacleTypes.ROOF) {
             const size = stream.readInt8()

--- a/client/src/store/entities/ammo.ts
+++ b/client/src/store/entities/ammo.ts
@@ -51,10 +51,10 @@ export default class Ammo extends Entity {
 	}
 
 	render(you: Player, canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, scale: number) {
-		you.position = Vec2.interpolate(you.oldPos, you.position, Math.min((Date.now() - you._lastPosChange) / getTPS()));
+		you.position = you.oldPos.interpolate(you.position, Math.min((Date.now() - you._lastPosChange) / getTPS()));
 		you._lastPosChange = Date.now()
 		you.oldPos = you.position
-		this.position = Vec2.interpolate(this.oldPos, this.position, Math.min((Date.now() - this._lastPosChange) / getTPS()));
+		this.position = this.oldPos.interpolate(this.position, Math.min((Date.now() - this._lastPosChange) / getTPS()));
 		this._lastPosChange = Date.now()
 		this.oldPos = this.position
 		const relative = this.position.addVec(you.position.inverse());

--- a/client/src/store/entities/player.ts
+++ b/client/src/store/entities/player.ts
@@ -117,10 +117,10 @@ export default class Player extends Entity {
 	}
 
 	render(you: Player, canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D, scale: number) {
-		you.position = Vec2.interpolate(you.oldPos, you.position, Math.min((Date.now() - you._lastPosChange) / getTPS()));
+		you.position = you.oldPos.interpolate(you.position, Math.min((Date.now() - you._lastPosChange) / getTPS()));
 		you._lastPosChange = Date.now()
 		you.oldPos = you.position
-		this.position = Vec2.interpolate(this.oldPos, this.position, Math.min((Date.now() - this._lastPosChange) / getTPS())); 
+		this.position = this.oldPos.interpolate(this.position, Math.min((Date.now() - this._lastPosChange) / getTPS())); 
 		this._lastPosChange = Date.now()
 		this.oldPos = this.position
 		/*you.direction = Vec2.interpolate(you.oldDir, you.direction, Math.min((Date.now() - you._lastPosChange) / getTPS()));

--- a/client/src/types/data.ts
+++ b/client/src/types/data.ts
@@ -56,6 +56,7 @@ export type GunData = {
 		tracer: TracerData
 		animations: string[]
 		hasBarrelImage: boolean
+		particleToDisplay: string
 	},
 	fistPositions?: Array<number>
 }
@@ -135,6 +136,7 @@ export type ObstacleData = {
 	type: string;
 	direction?: number[] | number;
 	position: number[];
+	special?: string;
 	[key: string]: any;
 }
 
@@ -151,7 +153,7 @@ export type BuildingData = {
 	roofs?: ObstacleData[];
 	mapColor?: number;
 	subBuildings?: {
-		id: "string",
+		id: string,
 		position: number[],
 		direction: number[]
 	}
@@ -183,6 +185,11 @@ export type MapBuildingData = {
 	direction?: number[];
 	amount?: number;
 	includeTerrains?: string[];
+	subBuildings?: {
+		id: string,
+		position: number[],
+		direction: number[]
+	}
 }
 
 export type MapObstacleData = {

--- a/client/src/types/math.ts
+++ b/client/src/types/math.ts
@@ -35,6 +35,10 @@ export class Vec2 {
 		return new Vec2(-this.x, -this.y);
 	}
 
+	invert() {
+		return new Vec2(this.y, this.x);
+	}
+
 	unit() {
 		const mag = this.magnitude();
 		if (mag === 0) return Vec2.ZERO;
@@ -67,9 +71,7 @@ export class Vec2 {
 	addVec(vec: Vec2) {
 		return new Vec2(this.x + vec.x, this.y + vec.y);
 	}
-	static addDiffVec(firstVec: Vec2, secondVec: Vec2) {
-		return new Vec2(firstVec.x+secondVec.x, firstVec.y+secondVec.y)
-	}
+
 	addX(x: number) {
 		return new Vec2(this.x + x, this.y);
 	}
@@ -80,9 +82,6 @@ export class Vec2 {
 
 	scale(x: number, y: number) {
 		return new Vec2(this.x * x, this.y * y);
-	}
-	static scaleDiffVec(vec: Vec2, x: number, y: number) {
-		return new Vec2(vec.x * x, vec.y * y)
 	}
 
 	scaleAll(ratio: number) {
@@ -101,6 +100,10 @@ export class Vec2 {
 		return Math.sqrt(this.distanceSqrTo(vec));
 	}
 
+	interpolate(endVec: Vec2, factor: number) {
+		return this.scaleAll(1-factor).addVec(endVec.scaleAll(factor));
+	}
+
 	perpendicular() {
 		return new Vec2(this.y, -this.x);
 	}
@@ -111,9 +114,6 @@ export class Vec2 {
 
 	minimize() {
 		return <MinVec2>{ x: this.x, y: this.y };
-	}
-	static interpolate(startVec: Vec2, endVec: Vec2, factor: number) {
-		return Vec2.addDiffVec(Vec2.scaleDiffVec(startVec,  1-factor, 1-factor), Vec2.scaleDiffVec(endVec, factor, factor))
 	}
 }
 

--- a/client/src/types/minimized.ts
+++ b/client/src/types/minimized.ts
@@ -22,14 +22,15 @@ export interface MinCircleHitbox {
 
 export type MinHitbox = MinRectHitbox | MinCircleHitbox;
 
-export interface MinEntity {
-	id: string;
-	type: number;
-	position: MinVec2;
-	direction: MinVec2;
-	hitbox: MinHitbox;
-	animations: string[];
-	despawn: boolean;
+export class MinEntity {
+	id!: string;
+	type!: number;
+	position!: MinVec2;
+	direction!: MinVec2;
+	hitbox!: MinHitbox;
+	_needsToSendAnimations!: boolean
+	animations!: string[];
+	despawn!: boolean;
 }
 
 export interface MinInventory {
@@ -47,6 +48,7 @@ export interface MinObstacle {
 	hitbox: MinHitbox;
 	despawn: boolean;
 	animations: string[];
+	_needToSendAnimations: boolean;
 }
 
 export interface MinMinObstacle {

--- a/client/src/types/misc.ts
+++ b/client/src/types/misc.ts
@@ -26,7 +26,16 @@ export enum GunColor {
 	RED = 1, // 12 gauge
 	BLUE = 2, // 7.62mm
 	GREEN = 3, // 5.56mm
+	BLACK = 4, // .50 AE
 	OLIVE = 5, // .308 Subsonic
+	ORANGE = 6, // Flare
+	PURPLE = 7, // .45 ACP
+	TEAL = 8, // 40mm
+	BROWN = 9, // potato
+	PINK = 10, // Heart
+	PURE_BLACK = 11, // Rainbow
+	CURSED = 12,
+	BUGLE = 13,
 }
 
 export type CountableString = {

--- a/client/src/types/weapon.ts
+++ b/client/src/types/weapon.ts
@@ -4,10 +4,10 @@ import { Renderable } from "./extenstions";
 import { roundRect } from "../utils";
 import { CircleHitbox, CommonAngles, CommonNumbers, Vec2 } from "./math";
 import { GunData, MeleeData } from "./data";
-import { GunColor } from "../constants";
 import { DEFINED_ANIMATIONS } from "../store/animations";
 import { getBarrelImagePath } from "../textures";
 import { getMode } from "../homepage";
+import { GunColor } from "./misc";
 
 export enum WeaponType {
 	MELEE = "melee",

--- a/common/types/data.ts
+++ b/common/types/data.ts
@@ -56,7 +56,9 @@ export type GunData = {
 		tracer: TracerData
 		animations: string[]
 		hasBarrelImage: boolean
-	}
+		particleToDisplay: string
+	},
+	fistPositions?: Array<number>
 }
 
 interface MeleeStats {
@@ -134,6 +136,7 @@ export type ObstacleData = {
 	type: string;
 	direction?: number[] | number;
 	position: number[];
+	special?: string;
 	[key: string]: any;
 }
 
@@ -149,6 +152,11 @@ export type BuildingData = {
 	floors?: TerrainData[];
 	roofs?: ObstacleData[];
 	mapColor?: number;
+	subBuildings?: {
+		id: string,
+		position: number[],
+		direction: number[]
+	}
 }
 
 export type RedZoneDataEntry = {
@@ -177,6 +185,11 @@ export type MapBuildingData = {
 	direction?: number[];
 	amount?: number;
 	includeTerrains?: string[];
+	subBuildings?: {
+		id: string,
+		position: number[],
+		direction: number[]
+	}
 }
 
 export type MapObstacleData = {

--- a/common/types/math.ts
+++ b/common/types/math.ts
@@ -35,6 +35,10 @@ export class Vec2 {
 		return new Vec2(-this.x, -this.y);
 	}
 
+	invert() {
+		return new Vec2(this.y, this.x);
+	}
+
 	unit() {
 		const mag = this.magnitude();
 		if (mag === 0) return Vec2.ZERO;
@@ -94,6 +98,10 @@ export class Vec2 {
 
 	distanceTo(vec: Vec2) {
 		return Math.sqrt(this.distanceSqrTo(vec));
+	}
+
+	interpolate(endVec: Vec2, factor: number) {
+		return this.scaleAll(1-factor).addVec(endVec.scaleAll(factor));
 	}
 
 	perpendicular() {

--- a/common/types/minimized.ts
+++ b/common/types/minimized.ts
@@ -22,14 +22,15 @@ export interface MinCircleHitbox {
 
 export type MinHitbox = MinRectHitbox | MinCircleHitbox;
 
-export interface MinEntity {
-	id: string;
-	type: string;
-	position: MinVec2;
-	direction: MinVec2;
-	hitbox: MinHitbox;
-	animations: string[];
-	despawn: boolean;
+export class MinEntity {
+	id!: string;
+	type!: number;
+	position!: MinVec2;
+	direction!: MinVec2;
+	hitbox!: MinHitbox;
+	_needsToSendAnimations!: boolean
+	animations!: string[];
+	despawn!: boolean;
 }
 
 export interface MinInventory {
@@ -41,17 +42,18 @@ export interface MinInventory {
 
 export interface MinObstacle {
 	id: string;
-	type: string;
+	type: number;
 	position: MinVec2;
 	direction: MinVec2;
 	hitbox: MinHitbox;
 	despawn: boolean;
 	animations: string[];
+	_needToSendAnimations: boolean;
 }
 
 export interface MinMinObstacle {
 	id: string;
-	type: string;
+	type: number;
 	position: MinVec2;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
-        "@damienvesper/bit-buffer": "^1.0.0",
         "body-parser": "^1.20.2",
         "csv-parser": "^3.0.0",
         "dotenv": "^16.3.1",
@@ -51,15 +50,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@damienvesper/bit-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@damienvesper/bit-buffer/-/bit-buffer-1.0.0.tgz",
-      "integrity": "sha512-lOlCSK4wFkT2vMH4gIgoXX/n6oywqljuG5znY7VHv2hvMwA+jE8r9T5txFdqxHK7P8LVdxkXhefXLM2MCDqlbw==",
-      "engines": {
-        "node": ">=18.8.0",
-        "pnpm": ">=8.6.0"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -3582,11 +3572,6 @@
       "requires": {
         "regenerator-runtime": "^0.14.0"
       }
-    },
-    "@damienvesper/bit-buffer": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@damienvesper/bit-buffer/-/bit-buffer-1.0.0.tgz",
-      "integrity": "sha512-lOlCSK4wFkT2vMH4gIgoXX/n6oywqljuG5znY7VHv2hvMwA+jE8r9T5txFdqxHK7P8LVdxkXhefXLM2MCDqlbw=="
     },
     "@eslint-community/eslint-utils": {
       "version": "4.4.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
-    "@damienvesper/bit-buffer": "^1.0.0",
     "body-parser": "^1.20.2",
     "csv-parser": "^3.0.0",
     "dotenv": "^16.3.1",

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -17,12 +17,23 @@
         "ws": "^8.7.0"
       },
       "devDependencies": {
+        "@damienvesper/bit-buffer": "^1.0.1",
         "@types/msgpack-lite": "^0.1.8",
         "@types/node": "^17.0.38",
         "@types/node-fetch": "^2.6.4",
         "@types/pako": "^2.0.0",
         "@types/ws": "^8.5.3",
         "typescript": "^4.7.2"
+      }
+    },
+    "node_modules/@damienvesper/bit-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@damienvesper/bit-buffer/-/bit-buffer-1.0.1.tgz",
+      "integrity": "sha512-9sRpqNevbCxTmI05mBA3WdaAB4P467XP7aiA/zwOZtWdAS90wIuokeZz9hrUgQlUUKAC4f5+/zqrblV6XdlnLA==",
+      "dev": true,
+      "engines": {
+        "node": ">=18.8.0",
+        "pnpm": ">=8.6.0"
       }
     },
     "node_modules/@types/msgpack-lite": {
@@ -306,6 +317,12 @@
     }
   },
   "dependencies": {
+    "@damienvesper/bit-buffer": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@damienvesper/bit-buffer/-/bit-buffer-1.0.1.tgz",
+      "integrity": "sha512-9sRpqNevbCxTmI05mBA3WdaAB4P467XP7aiA/zwOZtWdAS90wIuokeZz9hrUgQlUUKAC4f5+/zqrblV6XdlnLA==",
+      "dev": true
+    },
     "@types/msgpack-lite": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/@types/msgpack-lite/-/msgpack-lite-0.1.8.tgz",

--- a/server/package.json
+++ b/server/package.json
@@ -19,6 +19,7 @@
   },
   "homepage": "https://github.com/North-West-Wind/islandr.io#readme",
   "devDependencies": {
+    "@damienvesper/bit-buffer": "^1.0.1",
     "@types/msgpack-lite": "^0.1.8",
     "@types/node": "^17.0.38",
     "@types/node-fetch": "^2.6.4",

--- a/server/src/types/data.ts
+++ b/server/src/types/data.ts
@@ -57,7 +57,7 @@ export type GunData = {
 		animations: string[]
 		hasBarrelImage: boolean
 		particleToDisplay: string
-	}
+	},
 	fistPositions?: Array<number>
 }
 
@@ -153,7 +153,7 @@ export type BuildingData = {
 	roofs?: ObstacleData[];
 	mapColor?: number;
 	subBuildings?: {
-		id: "string",
+		id: string,
 		position: number[],
 		direction: number[]
 	}
@@ -186,10 +186,10 @@ export type MapBuildingData = {
 	amount?: number;
 	includeTerrains?: string[];
 	subBuildings?: {
-		id: "string",
+		id: string,
 		position: number[],
 		direction: number[]
-}
+	}
 }
 
 export type MapObstacleData = {

--- a/server/src/types/math.ts
+++ b/server/src/types/math.ts
@@ -35,6 +35,10 @@ export class Vec2 {
 		return new Vec2(-this.x, -this.y);
 	}
 
+	invert() {
+		return new Vec2(this.y, this.x);
+	}
+
 	unit() {
 		const mag = this.magnitude();
 		if (mag === 0) return Vec2.ZERO;
@@ -55,9 +59,7 @@ export class Vec2 {
 		if (this.y > 0) return angle;
 		else return -angle;
 	}
-	inverseAngle() {
-		return -this.angle()
-	}
+
 	addAngle(radian: number) {
 		const angle = this.angle();
 		if (isNaN(angle)) return new Vec2(this.x, this.y);
@@ -98,6 +100,10 @@ export class Vec2 {
 		return Math.sqrt(this.distanceSqrTo(vec));
 	}
 
+	interpolate(endVec: Vec2, factor: number) {
+		return this.scaleAll(1-factor).addVec(endVec.scaleAll(factor));
+	}
+
 	perpendicular() {
 		return new Vec2(this.y, -this.x);
 	}
@@ -108,12 +114,6 @@ export class Vec2 {
 
 	minimize() {
 		return <MinVec2>{ x: this.x, y: this.y };
-	}
-
-	invert() {
-		const oldX = this.x
-		const oldY = this.y
-		return new Vec2(this.y, this.x)
 	}
 }
 

--- a/server/src/types/minimized.ts
+++ b/server/src/types/minimized.ts
@@ -1,5 +1,3 @@
-import { IslandrBitStream } from "../packets";
-
 export interface MinVec2 {
 	x: number;
 	y: number;

--- a/server/src/types/misc.ts
+++ b/server/src/types/misc.ts
@@ -26,7 +26,16 @@ export enum GunColor {
 	RED = 1, // 12 gauge
 	BLUE = 2, // 7.62mm
 	GREEN = 3, // 5.56mm
+	BLACK = 4, // .50 AE
 	OLIVE = 5, // .308 Subsonic
+	ORANGE = 6, // Flare
+	PURPLE = 7, // .45 ACP
+	TEAL = 8, // 40mm
+	BROWN = 9, // potato
+	PINK = 10, // Heart
+	PURE_BLACK = 11, // Rainbow
+	CURSED = 12,
+	BUGLE = 13,
 }
 
 export type CountableString = {

--- a/server/src/types/packet.ts
+++ b/server/src/types/packet.ts
@@ -266,9 +266,9 @@ export class AnnouncePacket extends IPacketSERVER {
 	}
 	serialise() {
 		super.serialise();
-		this.stream.writeASCIIString(this.weaponUsed)
-		this.stream.writeASCIIString(this.killer)
-		this.stream.writeASCIIString(this.killed)
+		this.stream.writeASCIIString(this.weaponUsed, this.weaponUsed.length + 1);
+		this.stream.writeASCIIString(this.killer, this.killed.length + 1);
+		this.stream.writeASCIIString(this.killed, this.killed.length + 1);
 	}
 }
 


### PR DESCRIPTION
Fixed dependencies of bit stream package
Changed Vec2 interpolate static method to in-object method
Fixed SVGs for Firefox

We now have a script in `client/assets/svg-fixer.ts`. This script will scan the entire assets directory, and add `width` and `height` attributes to the `svg` tag if not found.